### PR TITLE
feat: use built-in functools.cached_property in py3.8+

### DIFF
--- a/autoprop/policies.py
+++ b/autoprop/policies.py
@@ -1,13 +1,18 @@
 #!/usr/bin/env python3
 
 import functools
+import sys
 
 from .cache import (
         CachedProperty, ConditionalCachedProperty,
         set_cached_attr, del_cached_attr,
 )
 from operator import attrgetter
-from backports.cached_property import cached_property
+
+if sys.version_info >= (3, 8):
+    from functools import cached_property
+else:
+    from backports.cached_property import cached_property
 
 _KNOWN_POLICIES = {}
 _MISSING = object()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ description-file = 'README.rst'
 requires-python = "~=3.6"
 requires = [
   'signature_dispatch',
-  'backports.cached-property',
+  'backports.cached-property;python_version<"3.8"',
 ]
 classifiers = [
   'Programming Language :: Python :: 3',


### PR DESCRIPTION
Use built-in functools.cached_property decorator in Python 3.8+,
and fall back to the 'backports.cached_property' only in older Python
versions.  This saves people from having to package this backport
on distributions that no longer ship Python < 3.8.