### PR TITLE
Remove useless shebang lines

### DIFF
--- a/autoprop/__init__.py
+++ b/autoprop/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 """
 Infer properties from accessor methods.
 

--- a/autoprop/cache.py
+++ b/autoprop/cache.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 _CACHE_ATTR = '__autoprop_cache'
 _SET_BY_USER = object()
 _UNSPECIFIED = object()

--- a/autoprop/decorators.py
+++ b/autoprop/decorators.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import inspect
 import re
 import functools

--- a/autoprop/policies.py
+++ b/autoprop/policies.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import functools
 import sys
 

--- a/tests/check_performance.py
+++ b/tests/check_performance.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 if __name__ == '__main__':
     import autoprop
     import nestedtext as nt

--- a/tests/test_autoprop.py
+++ b/tests/test_autoprop.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import pytest
 import autoprop
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python3
-
 import pytest
 import autoprop
 from enum import Enum, auto


### PR DESCRIPTION
These sources are not script-like (have no “`if __name__ == '__main__'`” or similar), except for `tests/check_performance.py`—and even that does not have the executable bit set—so the shebang lines are not useful.