### PR TITLE
Use flit_core as build-backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["flit"]
-build-backend = "flit.buildapi"
+requires = ["flit_core"]
+build-backend = "flit_core.buildapi"
 
 [tool.flit.metadata]
 module = "autoprop"


### PR DESCRIPTION
Switch build-backend from flit to flit_core per upstream recommendation.
flit_core has smaller dependency footprint as it does not include
the complete package manager.